### PR TITLE
ignore gateway named "mesh" on istio VirtualService rule

### DIFF
--- a/istio/virtual-service-to-gateway-ref.yaml
+++ b/istio/virtual-service-to-gateway-ref.yaml
@@ -16,6 +16,11 @@ spec:
   rule: |
     for(let gatewayTarget of (config.spec?.gateways || []))
     {
+      if (gatewayTarget === 'mesh')
+      {
+        continue;
+      }
+
       let gatewayNaming = gatewayTarget.split('/');
       if (gatewayNaming.length == 2) {
         let gatewayItem = 


### PR DESCRIPTION
spec from https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService